### PR TITLE
Add square mission trajectory and launch

### DIFF
--- a/gestelt_bringup/launch/sitl/seperate_trajectory_launch/square_mission.launch
+++ b/gestelt_bringup/launch/sitl/seperate_trajectory_launch/square_mission.launch
@@ -1,0 +1,15 @@
+<launch>
+  <!-- Launches square mission -->
+  <node pkg="gestelt_bringup" name="mission" type="square_mission.py">
+    <param name="is_simulation" value="True"/>
+  </node>
+
+  <!-- Start rosbag to record setpoints and positions -->
+  <arg name="record_topics" default="
+    (.*)mavros(.*)
+    (.*)traj_server(.*)
+    (.*)planner(.*)
+  " />
+  <node pkg="rosbag" type="record" name="record" output="screen"
+        args="-o /home/yash/agile_flight/gestelt_ws/data/ -e $(arg record_topics)"/>
+</launch>

--- a/gestelt_bringup/scripts/sitl_drone_bringup_square.sh
+++ b/gestelt_bringup/scripts/sitl_drone_bringup_square.sh
@@ -1,0 +1,63 @@
+#!/bin/bash
+
+SESSION="gz_sim_single_uav"
+SESSIONEXISTS=$(tmux list-sessions | grep $SESSION)
+
+#####
+# Directories
+#####
+SCRIPT_DIR="$( cd -- "$( dirname -- "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )/.."
+gestelt_bringup_DIR="$SCRIPT_DIR/.."
+PX4_AUTOPILOT_REPO_DIR="$SCRIPT_DIR/../../../PX4-Autopilot"
+
+#####
+# Sourcing
+#####
+SOURCE_WS="
+source $SCRIPT_DIR/../../../devel/setup.bash &&
+"
+# PX4 v1.13.0
+SOURCE_PX4_AUTOPILOT="
+source $PX4_AUTOPILOT_REPO_DIR/Tools/setup_gazebo.bash $PX4_AUTOPILOT_REPO_DIR $PX4_AUTOPILOT_REPO_DIR/build/px4_sitl_default &&
+export ROS_PACKAGE_PATH=$ROS_PACKAGE_PATH:$gestelt_bringup_DIR:$PX4_AUTOPILOT_REPO_DIR:$PX4_AUTOPILOT_REPO_DIR/Tools/sitl_gazebo &&
+"
+#####
+# Commands
+#####
+# Start Gazebo and PX4 SITL instances
+CMD_0="
+roslaunch gestelt_bringup sitl_drone.launch
+"
+
+# Start up drone commander (Handles taking off, execution of mission and landing etc.)
+CMD_1="
+roslaunch trajectory_server trajectory_server_node.launch rviz_config:=gz_sim
+"
+
+# Start up minimum snap trajectory planner and sampler
+CMD_2="
+roslaunch trajectory_planner trajectory_planner_node.launch
+"
+
+# Start up script to send commands
+CMD_3="roslaunch gestelt_bringup square_mission.launch"
+
+if [ "$SESSIONEXISTS" = "" ]
+then
+    tmux new-session -d -s $SESSION
+
+    tmux split-window -t $SESSION:0.0 -v
+    tmux split-window -t $SESSION:0.1 -h
+    tmux split-window -t $SESSION:0.0 -h
+
+    tmux send-keys -t $SESSION:0.0 "$SOURCE_PX4_AUTOPILOT $CMD_0" C-m
+    sleep 2
+    tmux send-keys -t $SESSION:0.1 "$SOURCE_WS $CMD_1" C-m
+    sleep 1
+    tmux send-keys -t $SESSION:0.2 "$SOURCE_WS $CMD_2" C-m
+    sleep 1
+    tmux send-keys -t $SESSION:0.3 "$SOURCE_WS $CMD_3" C-m
+fi
+
+# Attach session on the first window
+tmux attach-session -t "$SESSION:0"

--- a/gestelt_bringup/src/square_mission.py
+++ b/gestelt_bringup/src/square_mission.py
@@ -1,0 +1,158 @@
+#!/usr/bin/env python3
+import rospy
+from gestelt_msgs.msg import CommanderState, Goals, CommanderCommand
+from geometry_msgs.msg import Pose, Accel, PoseArray, AccelStamped, Twist
+from std_msgs.msg import Bool
+import time
+
+# Publishers for server commands and trajectory goals
+server_event_pub = rospy.Publisher('/traj_server/command', CommanderCommand, queue_size=10)
+waypoints_pub = rospy.Publisher('/planner/goals', Goals, queue_size=10)
+# For visualization of requested waypoints
+waypoints_pos_pub = rospy.Publisher('/planner/goals_pos', PoseArray, queue_size=10)
+waypoints_acc_pub = rospy.Publisher('/planner/goals_acc', AccelStamped, queue_size=10)
+
+# Storage for state feedback
+server_states = {}
+
+def check_traj_server_states(desired_state):
+    """Return True when all drones report the desired traj_server state."""
+    if not server_states:
+        rospy.logwarn("No Server states received!")
+        return False
+    for state in server_states.values():
+        if state.traj_server_state != desired_state:
+            return False
+    return True
+
+
+def publishCommand(event_enum):
+    cmd = CommanderCommand()
+    cmd.command = event_enum
+    server_event_pub.publish(cmd)
+
+
+def get_server_state_callback():
+    msg = rospy.wait_for_message('/traj_server/state', CommanderState, timeout=5.0)
+    server_states[str(msg.drone_id)] = msg
+
+
+def create_pose(x, y, z):
+    pose = Pose()
+    pose.position.x = x
+    pose.position.y = y
+    pose.position.z = z
+    # face forward along -Y (same as mission.py)
+    pose.orientation.x = 0.0
+    pose.orientation.y = 0.0
+    pose.orientation.z = -0.707
+    pose.orientation.w = 0.707
+    return pose
+
+
+def create_accel(ax, ay, az):
+    acc = Accel()
+    mask = Bool()
+    if ax is None:
+        mask.data = True
+    else:
+        acc.linear.x = ax
+        acc.linear.y = ay
+        acc.linear.z = az
+        mask.data = False
+    return acc, mask
+
+
+def create_vel(vx, vy, vz):
+    vel = Twist()
+    mask = Bool()
+    if vx is None:
+        mask.data = True
+    else:
+        vel.linear.x = vx
+        vel.linear.y = vy
+        vel.linear.z = vz
+        mask.data = False
+    return vel, mask
+
+def pub_waypoints(waypoints, accels, vels,
+                  time_factor_terminal=1.0, time_factor=0.6,
+                  max_vel=3.0, max_accel=5.0):
+    """Publish a Goals message with optional timing constraints."""
+    msg = Goals()
+    pos_msg = PoseArray()
+    acc_msg = AccelStamped()
+
+    msg.header.frame_id = 'world'
+    pos_msg.header.frame_id = 'world'
+    acc_msg.header.frame_id = 'world'
+
+    msg.waypoints = waypoints
+    msg.accelerations = [a[0] for a in accels]
+    msg.velocities = [v[0] for v in vels]
+    msg.accelerations_mask = [a[1] for a in accels]
+    msg.velocities_mask = [v[1] for v in vels]
+
+    msg.time_factor_terminal.data = time_factor_terminal
+    msg.time_factor.data = time_factor
+    msg.max_vel.data = max_vel
+    msg.max_acc.data = max_accel
+
+    pos_msg.poses = waypoints
+    if accels:
+        acc_msg.accel = accels[0][0]
+
+    waypoints_pub.publish(msg)
+    waypoints_pos_pub.publish(pos_msg)
+    waypoints_acc_pub.publish(acc_msg)
+
+def main():
+    rospy.init_node('square_mission', anonymous=True)
+    rate = rospy.Rate(5)
+    hover = False
+    mission = False
+
+    while not rospy.is_shutdown():
+        get_server_state_callback()
+        if check_traj_server_states('MISSION'):
+            mission = True
+        if check_traj_server_states('HOVER'):
+            hover = True
+
+        if mission:
+            break
+        elif not hover:
+            rospy.loginfo('Setting to HOVER mode!')
+            publishCommand(CommanderCommand.TAKEOFF)
+        else:
+            rospy.loginfo('Setting to MISSION mode!')
+            publishCommand(CommanderCommand.MISSION)
+        rate.sleep()
+
+    rospy.loginfo('Sending square waypoints to UAV')
+
+    waypoints = []
+    accels = []
+    vels = []
+
+    # 2 m square starting from current hover position (0, 1.8, 1.2)
+    waypoints.append(create_pose(2.0, 1.8, 1.2))
+    waypoints.append(create_pose(2.0, 3.8, 1.2))
+    waypoints.append(create_pose(0.0, 3.8, 1.2))
+    waypoints.append(create_pose(0.0, 1.8, 1.2))
+
+    for _ in waypoints:
+        accels.append(create_accel(None, None, None))
+        vels.append(create_vel(0.0, 0.0, 0.0))
+
+    pub_waypoints(waypoints, accels, vels,
+                  time_factor_terminal=1.0,
+                  time_factor=0.8,
+                  max_vel=4.0,
+                  max_accel=8.0)
+
+    rospy.spin()
+
+
+if __name__ == '__main__':
+    main()

--- a/gestelt_bringup/src/square_mission.py
+++ b/gestelt_bringup/src/square_mission.py
@@ -136,10 +136,11 @@ def main():
     vels = []
 
     # 2 m square starting from current hover position (0, 1.8, 1.2)
-    waypoints.append(create_pose(2.0, 1.8, 1.2))
-    waypoints.append(create_pose(2.0, 3.8, 1.2))
-    waypoints.append(create_pose(0.0, 3.8, 1.2))
-    waypoints.append(create_pose(0.0, 1.8, 1.2))
+    waypoints.append(create_pose(0.0, 0.0, 1.2))
+    waypoints.append(create_pose(2.0, 0.0, 1.2))
+    waypoints.append(create_pose(2.0, 2.0, 1.2))
+    waypoints.append(create_pose(0.0, 2.0, 1.2))
+    waypoints.append(create_pose(0.0, 0.0, 1.2))
 
     for _ in waypoints:
         accels.append(create_accel(None, None, None))

--- a/trajectory_server/src/traj_server.cpp
+++ b/trajectory_server/src/traj_server.cpp
@@ -186,12 +186,19 @@ void TrajServer::UAVPoseCB(const geometry_msgs::PoseStamped::ConstPtr &msg)
     }
   }
 
-  uav_pose_ = *msg; 
+  uav_pose_ = *msg;
   uav_poses_.push_back(uav_pose_);
 
   if (uav_poses_.size() > uint16_t(uav_pose_history_size_)) {
     uav_poses_.pop_front(); // Remove the oldest pose
   }
+
+  // Publish updated path for real-time visualization
+  nav_msgs::Path uav_path;
+  uav_path.header.stamp = ros::Time::now();
+  uav_path.header.frame_id = origin_frame_;
+  uav_path.poses.assign(uav_poses_.begin(), uav_poses_.end());
+  uav_path_pub_.publish(uav_path);
 
 }
 
@@ -499,14 +506,6 @@ void TrajServer::debugTimerCb(const ros::TimerEvent &e){
   state_msg.armed = uav_current_state_.armed;
 
   server_state_pub_.publish(state_msg);
-
-  // Publish UAV Pose history
-  nav_msgs::Path uav_path;
-  uav_path.header.stamp = ros::Time::now();
-  uav_path.header.frame_id = origin_frame_; 
-  uav_path.poses = std::vector<geometry_msgs::PoseStamped>(uav_poses_.begin(), uav_poses_.end());
-
-  uav_path_pub_.publish(uav_path);
 }
 
 /*circular traj callback*/

--- a/trajectory_server/src/traj_server.cpp
+++ b/trajectory_server/src/traj_server.cpp
@@ -62,7 +62,7 @@ void TrajServer::init(ros::NodeHandle& nh)
   /* Publishers */
   /////////////////
   pos_cmd_raw_pub_ = nh.advertise<mavros_msgs::PositionTarget>("/mavros/setpoint_raw/local", 50);
-  uav_path_pub_ = nh.advertise<nav_msgs::Path>("/uav_path_trajectory", 50);
+  uav_path_pub_ = nh.advertise<nav_msgs::Path>("/uav_path_trajectory", 1, true);
   server_state_pub_ = nh.advertise<gestelt_msgs::CommanderState>("/traj_server/state", 50);
   // reference_pub_ = nh.advertise<geometry_msgs::TwistStamped>("/reference/setpoint_test", 50);
   flat_reference_pub_ = nh.advertise<controller_msgs::FlatTarget>("/reference/flatsetpoint", 50);
@@ -187,6 +187,7 @@ void TrajServer::UAVPoseCB(const geometry_msgs::PoseStamped::ConstPtr &msg)
   }
 
   uav_pose_ = *msg;
+  uav_pose_.header.frame_id = origin_frame_;
   uav_poses_.push_back(uav_pose_);
 
   if (uav_poses_.size() > uint16_t(uav_pose_history_size_)) {


### PR DESCRIPTION
## Summary
- add mission script that commands a 2 m square flight path
- provide launch file and bring-up script for running the square mission
- rely on trajectory server path publisher for RViz trail
- publish path updates on each pose message so RViz shows the drone's trail in real time

## Testing
- `catkin_make --only-pkg-with-deps trajectory_server` *(command not found)*
- `colcon build --packages-select trajectory_server` *(command not found)*
- `apt-get install -y python3-catkin-tools` *(unable to locate package)*


------
https://chatgpt.com/codex/tasks/task_e_68c21d3c1880832cafa6cec914a7b965