### PR TITLE
Make square mission request full trajectory

### DIFF
--- a/README.md
+++ b/README.md
@@ -115,11 +115,14 @@ node records `/mavros/local_position/pose` samples into NumPy arrays under
 You can convert those arrays into a 3D plot with:
 
 ```bash
-rosrun gestelt_bringup plot_local_position.py --output trajectory.png
+python3 ~/Downloads/gestelt_ws/src/gestelt/gestelt_bringup/scripts/plot_local_position.py \
+  --positions ~/Downloads/gestelt_ws/src/gestelt/gestelt_bringup/collected_poses/positions.npy \
+  --timestamps ~/Downloads/gestelt_ws/src/gestelt/gestelt_bringup/collected_poses/timestamps.npy \
+  --output ~/Downloads/gestelt_ws/src/gestelt/gestelt_bringup/collected_poses/trajectory.png
 ```
 
-Use `--show` to open an interactive window or `--help` for additional options such as
-custom input paths and camera angles.
+Use `--show` to open an interactive window or `--help` for additional options such as custom input paths and camera
+angles.
 
 # Acknowledgements
 1. [EGO-Planner-V2 repo](https://github.com/ZJU-FAST-Lab/EGO-Planner-v2)

--- a/gestelt_bringup/scripts/plot_local_position.py
+++ b/gestelt_bringup/scripts/plot_local_position.py
@@ -133,8 +133,8 @@ def _make_trajectory_plot(
         ax.plot(xs, ys, zs, linewidth=2.0, color="#1f77b4")
 
     # Mark start (green) and end (red) points
-    ax.scatter(positions[0, 0], positions[0, 1], color='lime', s=60, label='Start', edgecolor='k', zorder=10)
-    ax.scatter(positions[-1, 0], positions[-1, 1], color='red', s=60, label='End', edgecolor='k', zorder=10)
+    ax.scatter(positions[0, 0], positions[0, 1], positions[0, 2], color='lime', s=60, label='Start', edgecolor='k', zorder=10)
+    ax.scatter(positions[-1, 0], positions[-1, 1], positions[-1, 2], color='red', s=60, label='End', edgecolor='k', zorder=10)
     ax.legend(loc="best")
 
     ax.set_xlabel("X [m]")
@@ -174,7 +174,8 @@ def _make_xyz_time_plot(
     fig, axes = plt.subplots(3, 1, figsize=(10, 8), sharex=True)
     labels = ['X [m]', 'Y [m]', 'Z [m]']
     for i, ax in enumerate(axes):
-        ax.plot(times, positions[:, i], label=labels[i])
+        relative_times = times - times[0]
+        ax.plot(relative_times, positions[:, i], label=labels[i])
         ax.set_ylabel(labels[i])
         ax.grid(True)
         ax.legend(loc='best')

--- a/gestelt_bringup/scripts/plot_local_position.py
+++ b/gestelt_bringup/scripts/plot_local_position.py
@@ -111,7 +111,7 @@ def _make_trajectory_plot(
     elev: float,
     azim: float,
 ) -> plt.Figure:
-    fig = plt.figure(figsize=(8, 6))
+    fig = plt.figure(figsize=(12, 6))
     ax = fig.add_subplot(projection="3d")
 
     xs, ys, zs = positions.T
@@ -132,6 +132,11 @@ def _make_trajectory_plot(
             )
         ax.plot(xs, ys, zs, linewidth=2.0, color="#1f77b4")
 
+    # Mark start (green) and end (red) points
+    ax.scatter(positions[0, 0], positions[0, 1], color='lime', s=60, label='Start', edgecolor='k', zorder=10)
+    ax.scatter(positions[-1, 0], positions[-1, 1], color='red', s=60, label='End', edgecolor='k', zorder=10)
+    ax.legend(loc="best")
+
     ax.set_xlabel("X [m]")
     ax.set_ylabel("Y [m]")
     ax.set_zlabel("Z [m]")
@@ -149,6 +154,73 @@ def _make_trajectory_plot(
         axis(center - max_range / 2.0 - margin, center + max_range / 2.0 + margin)
 
     return fig
+
+
+def _make_xyz_time_plot(
+    positions: np.ndarray,
+    times: Optional[np.ndarray],
+    output: Optional[Path] = None,
+    show: bool = False,
+):
+    if times is None or times.shape[0] != positions.shape[0]:
+        print("[plot_local_position] Skipping XYZ vs time plot (timestamps missing or mismatched).")
+        return
+
+    fig, axes = plt.subplots(3, 1, figsize=(10, 8), sharex=True)
+    labels = ['X [m]', 'Y [m]', 'Z [m]']
+    for i, ax in enumerate(axes):
+        ax.plot(times, positions[:, i], label=labels[i])
+        ax.set_ylabel(labels[i])
+        ax.grid(True)
+        ax.legend(loc='best')
+    axes[-1].set_xlabel('Time [s]')
+    fig.suptitle('X, Y, Z Position vs Time')
+
+    if output is not None:
+        out_path = output.parent / (output.stem + "_xyz_vs_time.png")
+        fig.savefig(out_path, bbox_inches="tight", dpi=600)
+        print(f"Saved X/Y/Z vs Time plot to {out_path}")
+
+    if show:
+        plt.show()
+    else:
+        plt.close(fig)
+
+
+def _make_xy_plot(
+    positions: np.ndarray,
+    times: Optional[np.ndarray],
+    output: Optional[Path] = None,
+    show: bool = False,
+):
+    fig, ax = plt.subplots(figsize=(7, 7))
+    if times is not None and times.shape[0] == positions.shape[0]:
+        sc = ax.scatter(positions[:, 0], positions[:, 1], c=times, cmap="viridis", s=8)
+        cbar = fig.colorbar(sc, ax=ax)
+        cbar.set_label("Time [s]")
+    else:
+        ax.plot(positions[:, 0], positions[:, 1], label="Trajectory")
+        ax.legend(loc="best")
+    ax.set_xlabel("X [m]")
+    ax.set_ylabel("Y [m]")
+    ax.set_title("XY Trajectory Projection")
+    ax.axis("equal")
+    ax.grid(True)
+
+    # Mark start (green) and end (red) points
+    ax.scatter(positions[0, 0], positions[0, 1], color='lime', s=60, label='Start', edgecolor='k', zorder=10)
+    ax.scatter(positions[-1, 0], positions[-1, 1], color='red', s=60, label='End', edgecolor='k', zorder=10)
+    ax.legend(loc="best")
+
+    if output is not None:
+        out_path = output.parent / (output.stem + "_xy.png")
+        fig.savefig(out_path, bbox_inches="tight", dpi=600)
+        print(f"Saved XY plot to {out_path}")
+
+    if show:
+        plt.show()
+    else:
+        plt.close(fig)
 
 
 def main(argv: Optional[list[str]] = None) -> None:
@@ -172,6 +244,10 @@ def main(argv: Optional[list[str]] = None) -> None:
         args.output.parent.mkdir(parents=True, exist_ok=True)
         fig.savefig(args.output, bbox_inches="tight", dpi=600)
         print(f"Saved 3D trajectory plot to {args.output}")
+
+    # --- Add this call to generate the XYZ vs time plot ---
+    _make_xyz_time_plot(positions, times, args.output, args.show)
+    _make_xy_plot(positions, times, args.output, args.show)
 
     if args.show:
         plt.show()

--- a/gestelt_bringup/scripts/plot_local_position.py
+++ b/gestelt_bringup/scripts/plot_local_position.py
@@ -111,7 +111,7 @@ def _make_trajectory_plot(
     elev: float,
     azim: float,
 ) -> plt.Figure:
-    fig = plt.figure(figsize=(8, 6))
+    fig = plt.figure(figsize=(12, 6))
     ax = fig.add_subplot(projection="3d")
 
     xs, ys, zs = positions.T
@@ -132,22 +132,95 @@ def _make_trajectory_plot(
             )
         ax.plot(xs, ys, zs, linewidth=2.0, color="#1f77b4")
 
+    # Mark start (green) and end (red) points
+    ax.scatter(positions[0, 0], positions[0, 1], color='lime', s=60, label='Start', edgecolor='k', zorder=10)
+    ax.scatter(positions[-1, 0], positions[-1, 1], color='red', s=60, label='End', edgecolor='k', zorder=10)
+    ax.legend(loc="best")
+
     ax.set_xlabel("X [m]")
     ax.set_ylabel("Y [m]")
     ax.set_zlabel("Z [m]")
     ax.set_title("MAVROS Local Position Trajectory")
     ax.view_init(elev=elev, azim=azim)
 
-    # Equal aspect ratio for XYZ dimensions.
+    # Equal aspect ratio for XYZ dimensions, with margin for better visibility.
     ranges = np.ptp(positions, axis=0)
     max_range = np.max(ranges)
     if max_range == 0:
         max_range = 1.0
+    margin = 0.15 * max_range  # 15% margin
     midpoints = np.mean(positions, axis=0)
     for center, axis in zip(midpoints, [ax.set_xlim, ax.set_ylim, ax.set_zlim]):
-        axis(center - max_range / 2.0, center + max_range / 2.0)
+        axis(center - max_range / 2.0 - margin, center + max_range / 2.0 + margin)
 
     return fig
+
+
+def _make_xyz_time_plot(
+    positions: np.ndarray,
+    times: Optional[np.ndarray],
+    output: Optional[Path] = None,
+    show: bool = False,
+):
+    if times is None or times.shape[0] != positions.shape[0]:
+        print("[plot_local_position] Skipping XYZ vs time plot (timestamps missing or mismatched).")
+        return
+
+    fig, axes = plt.subplots(3, 1, figsize=(10, 8), sharex=True)
+    labels = ['X [m]', 'Y [m]', 'Z [m]']
+    for i, ax in enumerate(axes):
+        ax.plot(times, positions[:, i], label=labels[i])
+        ax.set_ylabel(labels[i])
+        ax.grid(True)
+        ax.legend(loc='best')
+    axes[-1].set_xlabel('Time [s]')
+    fig.suptitle('X, Y, Z Position vs Time')
+
+    if output is not None:
+        out_path = output.parent / (output.stem + "_xyz_vs_time.png")
+        fig.savefig(out_path, bbox_inches="tight", dpi=600)
+        print(f"Saved X/Y/Z vs Time plot to {out_path}")
+
+    if show:
+        plt.show()
+    else:
+        plt.close(fig)
+
+
+def _make_xy_plot(
+    positions: np.ndarray,
+    times: Optional[np.ndarray],
+    output: Optional[Path] = None,
+    show: bool = False,
+):
+    fig, ax = plt.subplots(figsize=(7, 7))
+    if times is not None and times.shape[0] == positions.shape[0]:
+        sc = ax.scatter(positions[:, 0], positions[:, 1], c=times, cmap="viridis", s=8)
+        cbar = fig.colorbar(sc, ax=ax)
+        cbar.set_label("Time [s]")
+    else:
+        ax.plot(positions[:, 0], positions[:, 1], label="Trajectory")
+        ax.legend(loc="best")
+    ax.set_xlabel("X [m]")
+    ax.set_ylabel("Y [m]")
+    ax.set_title("XY Trajectory Projection")
+    ax.axis("equal")
+    ax.grid(True)
+
+    # Mark start (green) and end (red) points
+    ax.scatter(positions[0, 0], positions[0, 1], color='lime', s=60, label='Start', edgecolor='k', zorder=10)
+    ax.scatter(positions[-1, 0], positions[-1, 1], color='red', s=60, label='End', edgecolor='k', zorder=10)
+    ax.legend(loc="best")
+
+    if output is not None:
+        out_path = output.parent / (output.stem + "_xy.png")
+        fig.savefig(out_path, bbox_inches="tight", dpi=600)
+        print(f"Saved XY plot to {out_path}")
+
+    if show:
+        plt.show()
+    else:
+        plt.close(fig)
 
 
 def main(argv: Optional[list[str]] = None) -> None:
@@ -169,8 +242,12 @@ def main(argv: Optional[list[str]] = None) -> None:
 
     if args.output is not None:
         args.output.parent.mkdir(parents=True, exist_ok=True)
-        fig.savefig(args.output, bbox_inches="tight", dpi=150)
+        fig.savefig(args.output, bbox_inches="tight", dpi=600)
         print(f"Saved 3D trajectory plot to {args.output}")
+
+    # --- Add this call to generate the XYZ vs time plot ---
+    _make_xyz_time_plot(positions, times, args.output, args.show)
+    _make_xy_plot(positions, times, args.output, args.show)
 
     if args.show:
         plt.show()

--- a/gestelt_bringup/scripts/plot_local_position.py
+++ b/gestelt_bringup/scripts/plot_local_position.py
@@ -153,6 +153,11 @@ def _make_trajectory_plot(
     for center, axis in zip(midpoints, [ax.set_xlim, ax.set_ylim, ax.set_zlim]):
         axis(center - max_range / 2.0 - margin, center + max_range / 2.0 + margin)
 
+    # Set axis limits tightly to the data
+    ax.set_xlim(np.min(xs), np.max(xs))
+    ax.set_ylim(np.min(ys), np.max(ys))
+    ax.set_zlim(np.min(zs), np.max(zs))
+
     return fig
 
 

--- a/gestelt_bringup/src/square_mission.py
+++ b/gestelt_bringup/src/square_mission.py
@@ -122,7 +122,9 @@ def main():
     publishCommand(CommanderCommand.TAKEOFF)
     wait_for_state('HOVER')
 
-    # Define square corners at 1.2 m altitude
+    # Define square corners at 1.2 m altitude. The first waypoint matches the
+    # hover position so that the planner explicitly enforces a zero-velocity
+    # boundary condition before the vehicle leaves the origin.
     corners = [
         create_pose(0.0, 0.0, 1.2),
         create_pose(2.0, 0.0, 1.2),
@@ -131,20 +133,21 @@ def main():
         create_pose(0.0, 0.0, 1.2)
     ]
 
-    for idx, corner in enumerate(corners):
-        rospy.loginfo(f'Sending corner {idx + 1}')
-        acc = [create_accel(None, None, None)]
-        vel = [create_vel(0.0, 0.0, 0.0)]
+    # Request zero velocity at every corner so the planner produces straight
+    # edges instead of rounded turns.
+    velocities = [create_vel(0.0, 0.0, 0.0) for _ in corners]
+    accelerations = [create_accel(None, None, None) for _ in corners]
 
-        publishCommand(CommanderCommand.MISSION)
-        wait_for_state('MISSION')
-        pub_waypoints([corner], acc, vel,
-                      time_factor_terminal=1.0,
-                      time_factor=0.8,
-                      max_vel=4.0,
-                      max_accel=8.0)
-        wait_for_state('HOVER')
-        rospy.loginfo(f'Corner {idx + 1} reached')
+    rospy.loginfo('Sending full square trajectory')
+    publishCommand(CommanderCommand.MISSION)
+    wait_for_state('MISSION')
+    pub_waypoints(corners, accelerations, velocities,
+                  time_factor_terminal=1.0,
+                  time_factor=0.8,
+                  max_vel=4.0,
+                  max_accel=8.0)
+    wait_for_state('HOVER')
+    rospy.loginfo('Square trajectory complete')
 
     rospy.loginfo('Square mission complete')
     rospy.spin()


### PR DESCRIPTION
## Summary
- update the square mission to send the full set of square waypoints in a single request
- enforce zero-velocity constraints at each corner so the minimum-snap planner flies straight edges

## Testing
- python3 -m compileall gestelt_bringup/src/square_mission.py

------
https://chatgpt.com/codex/tasks/task_e_68cd6195ae30832c85ccc47f5bb3f5f1